### PR TITLE
Update cufft error enumeration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,13 +106,36 @@ SZIP_DIR = $(EBROOTSZIP)
 # Git hash of release 1.3
 GIT_HASH       = -D__KWAVE_GIT_HASH__=\"468dc31c2842a7df5f2a07c3a13c16c9b0b2b770\"
 
-# What CUDA GPU architectures to include in the binary
+# What CUDA GPU architectures to include in the binary.
+# Blackwell (sm_100, sm_120) compute capabilities were introduced in
+# CUDA 12.8, so the Blackwell entries are only added when the detected
+# nvcc version is >= 12.8. Older toolchains (CUDA 12.0-12.7) keep
+# building with just the Turing-Hopper list.
+#
+# Each new sm gets a forward-compatible PTX entry too
+# (`code=compute_*`) so future Blackwell sub-variants (sm_100a,
+# sm_121, etc.) can JIT-compile from PTX instead of being rejected
+# outright by the driver for lacking a native cubin.
 CUDA_ARCH = --generate-code arch=compute_75,code=sm_75 \
             --generate-code arch=compute_80,code=sm_80 \
             --generate-code arch=compute_87,code=sm_87 \
             --generate-code arch=compute_89,code=sm_89 \
             --generate-code arch=compute_90,code=sm_90 \
             --generate-code arch=compute_90a,code=sm_90a
+
+NVCC ?= $(CUDA_DIR)/bin/nvcc
+# Single nvcc invocation + awk parse: emits "yes" when the toolchain is
+# >= 12.8 (the first CUDA release to support Blackwell sm_100/sm_120).
+# Previous form was four separate $(shell) calls — each re-ran
+# `nvcc --version` (~50-200ms each) at Makefile parse time.
+CUDA_GE_1208 := $(shell $(NVCC) --version 2>/dev/null | awk '/release/ {split($$0,a,"release "); split(a[2],b,"[., ]"); if (b[1]*100+b[2] >= 1208) print "yes"; exit}')
+
+ifeq ($(CUDA_GE_1208),yes)
+  CUDA_ARCH += --generate-code arch=compute_100,code=sm_100 \
+               --generate-code arch=compute_100,code=compute_100 \
+               --generate-code arch=compute_120,code=sm_120 \
+               --generate-code arch=compute_120,code=compute_120
+endif
 
 # What libraries to link and how
 ifeq ($(LINKING), STATIC)

--- a/MatrixClasses/CufftComplexMatrix.cpp
+++ b/MatrixClasses/CufftComplexMatrix.cpp
@@ -59,22 +59,19 @@ cufftHandle CufftComplexMatrix::sC2RFftPlan1DZ = cufftHandle();
  */
 std::map<cufftResult, ErrorMessage> CufftComplexMatrix::sCufftErrorMessages
 {
-  {CUFFT_INVALID_PLAN             , kErrFmtCufftInvalidPlan},
-  {CUFFT_ALLOC_FAILED             , kErrFmtCufftAllocFailed},
-  {CUFFT_INVALID_TYPE             , kErrFmtCufftInvalidType},
-  {CUFFT_INVALID_VALUE            , kErrFmtCufftInvalidValue},
-  {CUFFT_INTERNAL_ERROR           , kErrFmtCuFFTInternalError},
-  {CUFFT_EXEC_FAILED              , kErrFmtCufftExecFailed},
-  {CUFFT_SETUP_FAILED             , kErrFmtCufftSetupFailed},
-  {CUFFT_INVALID_SIZE             , kErrFmtCufftInvalidSize},
-  {CUFFT_UNALIGNED_DATA           , kErrFmtCufftUnalignedData},
-  {CUFFT_INCOMPLETE_PARAMETER_LIST, kErrFmtCufftIncompleteParaterList},
-  {CUFFT_INVALID_DEVICE           , kErrFmtCufftInvalidDevice},
-  {CUFFT_PARSE_ERROR              , kErrFmtCufftParseError},
-  {CUFFT_NO_WORKSPACE             , kErrFmtCufftNoWorkspace},
-  {CUFFT_NOT_IMPLEMENTED          , kErrFmtCufftNotImplemented},
-  {CUFFT_LICENSE_ERROR            , kErrFmtCufftLicenseError},
-  {CUFFT_NOT_SUPPORTED            , kErrFmtCufftNotSupported}
+  {CUFFT_INVALID_PLAN  , kErrFmtCufftInvalidPlan},
+  {CUFFT_ALLOC_FAILED  , kErrFmtCufftAllocFailed},
+  {CUFFT_INVALID_TYPE  , kErrFmtCufftInvalidType},
+  {CUFFT_INVALID_VALUE , kErrFmtCufftInvalidValue},
+  {CUFFT_INTERNAL_ERROR, kErrFmtCuFFTInternalError},
+  {CUFFT_EXEC_FAILED   , kErrFmtCufftExecFailed},
+  {CUFFT_SETUP_FAILED  , kErrFmtCufftSetupFailed},
+  {CUFFT_INVALID_SIZE  , kErrFmtCufftInvalidSize},
+  {CUFFT_UNALIGNED_DATA, kErrFmtCufftUnalignedData},
+  {CUFFT_INVALID_DEVICE, kErrFmtCufftInvalidDevice},
+  {CUFFT_NO_WORKSPACE  , kErrFmtCufftNoWorkspace},
+  {CUFFT_NOT_IMPLEMENTED, kErrFmtCufftNotImplemented},
+  {CUFFT_NOT_SUPPORTED , kErrFmtCufftNotSupported}
 };
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/MatrixClasses/CufftComplexMatrix.cpp
+++ b/MatrixClasses/CufftComplexMatrix.cpp
@@ -71,7 +71,17 @@ std::map<cufftResult, ErrorMessage> CufftComplexMatrix::sCufftErrorMessages
   {CUFFT_INVALID_DEVICE, kErrFmtCufftInvalidDevice},
   {CUFFT_NO_WORKSPACE  , kErrFmtCufftNoWorkspace},
   {CUFFT_NOT_IMPLEMENTED , kErrFmtCufftNotImplemented},
-  {CUFFT_NOT_SUPPORTED , kErrFmtCufftNotSupported}
+  {CUFFT_NOT_SUPPORTED , kErrFmtCufftNotSupported},
+  // Codes deprecated in cuFFT 12.9 and removed in 13.0; preserved
+  // here when building against older toolchains so cuFFT 12.x users
+  // still get descriptive error messages instead of the generic
+  // "unknown error" fallback. CUDART_VERSION is exposed by
+  // <cuda_runtime_api.h> via the cufft.h include above.
+#if CUDART_VERSION < 13000
+  {CUFFT_INCOMPLETE_PARAMETER_LIST, kErrFmtCufftIncompleteParaterList},
+  {CUFFT_PARSE_ERROR              , kErrFmtCufftParseError},
+  {CUFFT_LICENSE_ERROR            , kErrFmtCufftLicenseError},
+#endif
 };
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/MatrixClasses/CufftComplexMatrix.cpp
+++ b/MatrixClasses/CufftComplexMatrix.cpp
@@ -70,7 +70,7 @@ std::map<cufftResult, ErrorMessage> CufftComplexMatrix::sCufftErrorMessages
   {CUFFT_UNALIGNED_DATA, kErrFmtCufftUnalignedData},
   {CUFFT_INVALID_DEVICE, kErrFmtCufftInvalidDevice},
   {CUFFT_NO_WORKSPACE  , kErrFmtCufftNoWorkspace},
-  {CUFFT_NOT_IMPLEMENTED, kErrFmtCufftNotImplemented},
+  {CUFFT_NOT_IMPLEMENTED , kErrFmtCufftNotImplemented},
   {CUFFT_NOT_SUPPORTED , kErrFmtCufftNotSupported}
 };
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated GPU FFT error mapping to align with current library codes and standardized formatting. Some rare cuFFT failures may now surface as “Unknown error,” while common errors continue to show descriptive messages. No changes to user workflows or public interfaces; overall functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the cuFFT error-code map in `CufftComplexMatrix.cpp` to reflect the current library API — adding codes that were previously missing (`CUFFT_INVALID_DEVICE`, `CUFFT_NO_WORKSPACE`, `CUFFT_NOT_IMPLEMENTED`, `CUFFT_NOT_SUPPORTED`) and conditionally compiling three deprecated codes (`CUFFT_INCOMPLETE_PARAMETER_LIST`, `CUFFT_PARSE_ERROR`, `CUFFT_LICENSE_ERROR`) only when building against CUDA < 13.0. The `Makefile` gains a one-shot `nvcc` version probe that conditionally appends Blackwell (`sm_100`, `sm_120`) GPU architecture targets when the toolchain is CUDA ≥ 12.8.

- **`CufftComplexMatrix.cpp`**: Four previously-unmapped cuFFT result codes are now in the error map; three deprecated codes are guarded with `#if CUDART_VERSION < 13000` so builds against CUDA 13.0+ remain clean while CUDA 12.x users still get descriptive messages.
- **`Makefile`**: Replaces multiple `$(shell nvcc --version)` calls with a single `nvcc --version | awk` pipeline, and uses the result to conditionally include Blackwell PTX/cubin targets only when the toolchain supports them.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are a straightforward map update with a well-scoped preprocessor guard and an additive Makefile improvement.

The cuFFT error-map changes correctly add missing codes and guard the removed ones behind CUDART_VERSION < 13000. CUDART_VERSION is reliably defined by cuda_runtime_api.h, which cufft.h includes transitively, so the guard is sound. The Makefile awk version probe is correct and the 2>/dev/null fallback gracefully handles missing or mismatched toolchains by simply skipping the Blackwell targets. No logic that could cause wrong results or data corruption was touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| MatrixClasses/CufftComplexMatrix.cpp | Error-code map updated to add four missing cuFFT result codes and conditionally compile three deprecated codes behind a CUDART_VERSION guard; newline-at-EOF also fixed. |
| Makefile | Adds NVCC version probe and conditional Blackwell (sm_100/sm_120) arch flags; consolidates multiple nvcc --version shell calls into one awk pipeline. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cuFFT operation returns cufftResult] --> B{sCufftErrorMessages.find}
    B -- found --> C[Format descriptive error message]
    B -- not found --> D[Format generic 'unknown error' message]
    C --> E[throw std::runtime_error]
    D --> E

    subgraph Error Map Population at startup
        F[Unconditional entries]
        G{CUDART_VERSION < 13000?}
        G -- yes --> H[Also add deprecated codes]
        G -- no --> I[Deprecated codes omitted]
    end
```

<sub>Reviews (5): Last reviewed commit: ["Bump CUDA SM support to 120 (Blackwell) ..."](https://github.com/waltsims/kspacefirstorder-cuda-linux/commit/95a887a7d69437c2533c418644d591951abb5c29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32456343)</sub>

<!-- /greptile_comment -->