### PR TITLE
Bump CUDA SM support to 120 (Blackwell)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,13 +124,13 @@ CUDA_ARCH = --generate-code arch=compute_75,code=sm_75 \
             --generate-code arch=compute_90a,code=sm_90a
 
 NVCC ?= $(CUDA_DIR)/bin/nvcc
-CUDA_MAJOR := $(shell $(NVCC) --version 2>/dev/null | sed -n 's/.*release \([0-9]*\)\.[0-9]*.*/\1/p')
-CUDA_MINOR := $(shell $(NVCC) --version 2>/dev/null | sed -n 's/.*release [0-9]*\.\([0-9]*\).*/\1/p')
-# Combined as a single MMmm integer (1208 = 12.8, 1300 = 13.0, ...) so
-# the comparison below is one numeric test instead of nested major/minor.
-CUDA_VERSION_NUM := $(shell test -n "$(CUDA_MAJOR)" -a -n "$(CUDA_MINOR)" && echo $$(( $(CUDA_MAJOR) * 100 + $(CUDA_MINOR) )))
+# Single nvcc invocation + awk parse: emits "yes" when the toolchain is
+# >= 12.8 (the first CUDA release to support Blackwell sm_100/sm_120).
+# Previous form was four separate $(shell) calls — each re-ran
+# `nvcc --version` (~50-200ms each) at Makefile parse time.
+CUDA_GE_1208 := $(shell $(NVCC) --version 2>/dev/null | awk '/release/ {split($$0,a,"release "); split(a[2],b,"[., ]"); if (b[1]*100+b[2] >= 1208) print "yes"; exit}')
 
-ifeq ($(shell test -n "$(CUDA_VERSION_NUM)" && test $(CUDA_VERSION_NUM) -ge 1208 && echo yes),yes)
+ifeq ($(CUDA_GE_1208),yes)
   CUDA_ARCH += --generate-code arch=compute_100,code=sm_100 \
                --generate-code arch=compute_100,code=compute_100 \
                --generate-code arch=compute_120,code=sm_120 \

--- a/Makefile
+++ b/Makefile
@@ -106,13 +106,36 @@ SZIP_DIR = $(EBROOTSZIP)
 # Git hash of release 1.3
 GIT_HASH       = -D__KWAVE_GIT_HASH__=\"468dc31c2842a7df5f2a07c3a13c16c9b0b2b770\"
 
-# What CUDA GPU architectures to include in the binary
+# What CUDA GPU architectures to include in the binary.
+# Blackwell (sm_100, sm_120) compute capabilities were introduced in
+# CUDA 12.8, so the Blackwell entries are only added when the detected
+# nvcc version is >= 12.8. Older toolchains (CUDA 12.0-12.7) keep
+# building with just the Turing-Hopper list.
+#
+# Each new sm gets a forward-compatible PTX entry too
+# (`code=compute_*`) so future Blackwell sub-variants (sm_100a,
+# sm_121, etc.) can JIT-compile from PTX instead of being rejected
+# outright by the driver for lacking a native cubin.
 CUDA_ARCH = --generate-code arch=compute_75,code=sm_75 \
             --generate-code arch=compute_80,code=sm_80 \
             --generate-code arch=compute_87,code=sm_87 \
             --generate-code arch=compute_89,code=sm_89 \
             --generate-code arch=compute_90,code=sm_90 \
             --generate-code arch=compute_90a,code=sm_90a
+
+NVCC ?= $(CUDA_DIR)/bin/nvcc
+CUDA_MAJOR := $(shell $(NVCC) --version 2>/dev/null | sed -n 's/.*release \([0-9]*\)\.[0-9]*.*/\1/p')
+CUDA_MINOR := $(shell $(NVCC) --version 2>/dev/null | sed -n 's/.*release [0-9]*\.\([0-9]*\).*/\1/p')
+# Combined as a single MMmm integer (1208 = 12.8, 1300 = 13.0, ...) so
+# the comparison below is one numeric test instead of nested major/minor.
+CUDA_VERSION_NUM := $(shell test -n "$(CUDA_MAJOR)" -a -n "$(CUDA_MINOR)" && echo $$(( $(CUDA_MAJOR) * 100 + $(CUDA_MINOR) )))
+
+ifeq ($(shell test -n "$(CUDA_VERSION_NUM)" && test $(CUDA_VERSION_NUM) -ge 1208 && echo yes),yes)
+  CUDA_ARCH += --generate-code arch=compute_100,code=sm_100 \
+               --generate-code arch=compute_100,code=compute_100 \
+               --generate-code arch=compute_120,code=sm_120 \
+               --generate-code arch=compute_120,code=compute_120
+endif
 
 # What libraries to link and how
 ifeq ($(LINKING), STATIC)


### PR DESCRIPTION
Closes #2. Adds Blackwell support to the Linux CUDA build. Mirrors the [Windows-side PR #1](https://github.com/waltsims/kspaceFirstOrder-CUDA-windows/pull/1).

## Changes

\`Makefile\` — extend \`CUDA_ARCH\` with three new \`--generate-code\` entries:
- \`sm_100\` — Blackwell datacenter (B100, B200, GB200)
- \`sm_120\` — Blackwell consumer (RTX 50xx series, e.g. RTX 5070 Ti / 5080 / 5090)
- PTX \`compute_120\` — forward-compatible intermediate so future Blackwell variants (e.g. \`sm_121\`, \`sm_130\`) can JIT from PTX without a rebuild

## Build requirements

Requires CUDA 13.0+ to build (\`sm_120\` was added in CUDA 13). The unified build CI in [\`kspacefirstorder-unified\`](https://github.com/waltsims/kspacefirstorder-unified/blob/main/.github/workflows/ci-multi-platform.yml) already matrices CUDA 12.2.0 + 13.0.0, so once this is merged and the unified submodule SHA is bumped, the 13.0.0 leg of the matrix will produce a Blackwell-capable artifact.

## Issues unblocked

- waltsims/k-wave-python#656 (RTX 5070 Ti / sm_120 segfaults)
- waltsims/k-wave-python#622 (\"Can not use kspaceFirstOrder-CUDA\" — turned out to be the same Blackwell sm gap per @faberno's [comment](https://github.com/waltsims/k-wave-python/issues/622#issuecomment-2273106886))

## Follow-up

- \`sm_103\` (Blackwell B300 variant) is also listed in CUDA 13's supported architectures but not added here. Niche datacenter SKU; trivial follow-up if/when needed.
- Once this and the Windows PR land, bump submodule SHAs in \`kspacefirstorder-unified\`, run CI, attach artifacts to a new v1.4.0 release on this repo and on \`kspaceFirstOrder-CUDA-windows\`, then bump the version pin in \`k-wave-python/kwave/__init__.py:56,63\`.

## Notes

Targeting the \`cuda-12-support\` branch (not \`main\`) because that's what \`kspacefirstorder-unified\` pins as a submodule. If you'd rather land on \`main\` first, happy to retarget — let me know.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Linux CUDA build's `CUDA_ARCH` variable with Blackwell targets (`sm_100`, `sm_120`) and their forward-compatible PTX entries, guarded by an awk-based version check that enables them only when the detected `nvcc` is ≥ 12.8. Both previously flagged gaps — the missing `compute_100,code=compute_100` PTX fallback and the too-strict `>= 13` version guard — are addressed in the current revision.

- Adds `sm_100` (datacenter Blackwell) and `sm_120` (consumer Blackwell) cubins plus matching `code=compute_100` / `code=compute_120` PTX entries so future sub-variants can JIT-compile instead of being rejected by the driver.
- Replaces four separate `nvcc --version` shell invocations with a single `nvcc --version | awk` pipeline, computing `major*100+minor >= 1208` to gate the Blackwell flags on CUDA 12.8+.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the Blackwell gencode entries and PTX fallbacks are correct, and the version guard accurately targets CUDA 12.8+.

The awk expression correctly computes major*100+minor >= 1208, the $$0 escaping is right for a Makefile $(shell …) context, PTX fallbacks are present for both sm_100 and sm_120, and silent degradation on older toolchains is handled cleanly. Both issues raised in earlier review rounds — missing compute_100 PTX entry and an overly strict >= 13 threshold — are resolved in this revision.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Makefile | Adds Blackwell sm_100/sm_120 gencode entries with PTX fallbacks, gated by an awk-based CUDA >= 12.8 version check; logic and escaping are correct, previous concerns about PTX coverage and version threshold are resolved. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Makefile`, line 41-42 ([link](https://github.com/waltsims/kspacefirstorder-cuda-linux/blob/65fbec67da6299a775c71d2ada718fc2d1aeba58/Makefile#L41-L42)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> This comment was written when the codebase only supported CUDA 10.x, but the newly added `sm_100` and `sm_120` targets require CUDA 13.0+. Left as-is, it will mislead anyone reading the build requirements.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Collapse CUDA version detection into a s..."](https://github.com/waltsims/kspacefirstorder-cuda-linux/commit/88ee054562fbd85dd69d059cde87752fddd6743d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32456324)</sub>

<!-- /greptile_comment -->