### PR TITLE
Add CMakeLists.txt + Blackwell-aware SetupCUDA.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 *.swp
 kspaceFirstOrder-CUDA
+build/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,207 @@
+cmake_minimum_required(VERSION 3.24)
+
+if(POLICY CMP0104)
+  cmake_policy(SET CMP0104 NEW) # CUDA architecture handling
+endif()
+if(POLICY CMP0146)
+  cmake_policy(SET CMP0146 NEW) # CUDA Clang host compilation
+endif()
+
+project(kspaceFirstOrderCUDA LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# -------------------------------------------------------------------------------------------------
+# Options mirroring the legacy Makefile switches
+# -------------------------------------------------------------------------------------------------
+set(KSPACE_CPU_ARCH "native" CACHE STRING "Target CPU ISA tuning (native, avx, avx2, avx512).")
+set_property(CACHE KSPACE_CPU_ARCH PROPERTY STRINGS native avx avx2 avx512)
+
+option(KSPACE_ENABLE_OPENMP "Enable OpenMP parallelism in host code." ON)
+option(KSPACE_ENABLE_FAST_MATH "Enable aggressive fast-math flags on the host compiler." ON)
+
+set(KSPACE_CUDA_ARCH_LIST "" CACHE STRING "Override CUDA architectures (semicolon, space, or comma separated).")
+
+if(KSPACE_CUDA_ARCH_LIST)
+  set(CMAKE_CUDA_ARCHITECTURES "${KSPACE_CUDA_ARCH_LIST}")
+elseif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  # Default to modern architectures supported by current CUDA toolkits.
+  # sm_100/sm_120 (Blackwell) require CUDA 12.8+; SetupCUDA.cmake drops
+  # them automatically when an older toolchain is detected.
+  # Override via KSPACE_CUDA_ARCH_LIST if needed.
+  set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;120")
+endif()
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SetupCUDA.cmake)
+
+set(CMAKE_CUDA_STANDARD 11)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_EXTENSIONS OFF)
+
+set(_fallback_git_hash "468dc31c2842a7df5f2a07c3a13c16c9b0b2b770")
+if(NOT DEFINED KSPACE_GIT_HASH)
+  set(_detected_hash "")
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    execute_process(
+      COMMAND git rev-parse HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE _git_hash_out
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      RESULT_VARIABLE _git_hash_status
+    )
+    if(_git_hash_status EQUAL 0 AND NOT _git_hash_out STREQUAL "")
+      set(_detected_hash "${_git_hash_out}")
+    endif()
+  endif()
+  if(NOT _detected_hash)
+    set(_detected_hash "${_fallback_git_hash}")
+  endif()
+  set(KSPACE_GIT_HASH "${_detected_hash}" CACHE STRING "Value propagated to __KWAVE_GIT_HASH__.")
+endif()
+mark_as_advanced(KSPACE_GIT_HASH)
+
+# -------------------------------------------------------------------------------------------------
+# Dependencies
+# -------------------------------------------------------------------------------------------------
+find_package(CUDAToolkit REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS C HL)
+find_package(ZLIB REQUIRED)
+find_package(SZIP QUIET)
+
+if(KSPACE_ENABLE_OPENMP)
+  find_package(OpenMP)
+  if(NOT OpenMP_CXX_FOUND)
+    message(WARNING "OpenMP requested but not found; disabling.")
+    set(KSPACE_ENABLE_OPENMP OFF CACHE BOOL "Enable OpenMP parallelism in host code." FORCE)
+  endif()
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Source lists
+# -------------------------------------------------------------------------------------------------
+set(KSPACE_CXX_SOURCES
+  main.cpp
+  Containers/MatrixContainer.cpp
+  Containers/OutputStreamContainer.cpp
+  Hdf5/Hdf5File.cpp
+  Hdf5/Hdf5FileHeader.cpp
+  KSpaceSolver/KSpaceFirstOrderSolver.cpp
+  Logger/Logger.cpp
+  MatrixClasses/BaseFloatMatrix.cpp
+  MatrixClasses/BaseIndexMatrix.cpp
+  MatrixClasses/ComplexMatrix.cpp
+  MatrixClasses/CufftComplexMatrix.cpp
+  MatrixClasses/IndexMatrix.cpp
+  MatrixClasses/RealMatrix.cpp
+  OutputStreams/BaseOutputStream.cpp
+  OutputStreams/CuboidOutputStream.cpp
+  OutputStreams/IndexOutputStream.cpp
+  OutputStreams/WholeDomainOutputStream.cpp
+  Parameters/CommandLineParameters.cpp
+  Parameters/CudaParameters.cpp
+  Parameters/Parameters.cpp
+)
+
+set(KSPACE_CUDA_SOURCES
+  Containers/CudaMatrixContainer.cu
+  KSpaceSolver/SolverCudaKernels.cu
+  MatrixClasses/TransposeCudaKernels.cu
+  OutputStreams/OutputStreamsCudaKernels.cu
+  Parameters/CudaDeviceConstants.cu
+)
+
+add_executable(kspaceFirstOrder-CUDA
+  ${KSPACE_CXX_SOURCES}
+  ${KSPACE_CUDA_SOURCES}
+)
+
+target_include_directories(kspaceFirstOrder-CUDA
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_property(TARGET kspaceFirstOrder-CUDA PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+set_property(TARGET kspaceFirstOrder-CUDA PROPERTY CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+
+# -------------------------------------------------------------------------------------------------
+# Host and device compiler flags
+# -------------------------------------------------------------------------------------------------
+set(_cpu_arch_value "${KSPACE_CPU_ARCH}")
+string(TOLOWER "${_cpu_arch_value}" _cpu_arch_value)
+
+set(_cpu_arch_flags "")
+if(_cpu_arch_value STREQUAL "native")
+  list(APPEND _cpu_arch_flags "-march=native" "-mtune=native")
+elseif(_cpu_arch_value STREQUAL "avx")
+  list(APPEND _cpu_arch_flags "-m64" "-mavx")
+elseif(_cpu_arch_value STREQUAL "avx2")
+  list(APPEND _cpu_arch_flags "-m64" "-mavx2")
+elseif(_cpu_arch_value STREQUAL "avx512")
+  list(APPEND _cpu_arch_flags "-m64" "-mavx512f")
+else()
+  message(FATAL_ERROR "Unsupported value for KSPACE_CPU_ARCH: ${KSPACE_CPU_ARCH}")
+endif()
+
+set(_host_opt_flags "-O3")
+if(KSPACE_ENABLE_FAST_MATH)
+  list(APPEND _host_opt_flags "-ffast-math" "-fassociative-math")
+endif()
+
+if(KSPACE_ENABLE_OPENMP AND OpenMP_CXX_FOUND)
+  set(_openmp_flags "${OpenMP_CXX_FLAGS}")
+  if(_openmp_flags)
+    separate_arguments(_openmp_flag_list NATIVE_COMMAND "${_openmp_flags}")
+    list(APPEND _host_opt_flags ${_openmp_flag_list})
+  endif()
+  target_link_libraries(kspaceFirstOrder-CUDA PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+target_compile_options(kspaceFirstOrder-CUDA
+  PRIVATE
+    $<$<COMPILE_LANGUAGE:CXX>:${_cpu_arch_flags}>
+    $<$<COMPILE_LANGUAGE:CXX>:${_host_opt_flags}>
+)
+
+set(_cuda_compile_flags "-O3" "--restrict" "--device-c")
+foreach(flag IN LISTS _cpu_arch_flags _host_opt_flags)
+  list(APPEND _cuda_compile_flags "-Xcompiler=${flag}")
+endforeach()
+
+target_compile_options(kspaceFirstOrder-CUDA
+  PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:${_cuda_compile_flags}>
+)
+
+# -------------------------------------------------------------------------------------------------
+# Defines and link libraries
+# -------------------------------------------------------------------------------------------------
+target_compile_definitions(kspaceFirstOrder-CUDA
+  PRIVATE
+    "__KWAVE_GIT_HASH__=\"${KSPACE_GIT_HASH}\""
+)
+
+set(_hdf5_link_targets HDF5::HDF5)
+if(TARGET hdf5::hdf5_hl)
+  list(APPEND _hdf5_link_targets hdf5::hdf5_hl)
+else()
+  message(FATAL_ERROR "HDF5 high-level component not found; ensure libhdf5_hl is installed.")
+endif()
+
+target_link_libraries(kspaceFirstOrder-CUDA
+  PRIVATE
+    CUDA::cudart
+    CUDA::cufft
+    ${_hdf5_link_targets}
+    ZLIB::ZLIB
+    dl
+)
+
+if(SZIP_FOUND)
+  target_link_libraries(kspaceFirstOrder-CUDA PRIVATE SZIP::SZIP)
+endif()
+
+# TODO: Replicate the Makefile rpath behaviour once install/runtime layout is defined.
+# TODO: Evaluate vcpkg or similar for provisioning HDF5/zlib when packaging.

--- a/cmake/SetupCUDA.cmake
+++ b/cmake/SetupCUDA.cmake
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# In this file, we:
+# 1. Set a default value for CMAKE_CUDA_ARCHITECTURES
+# 2. Use enable_language(CUDA) to retrieve CMAKE_CUDA_COMPILER_ID and CMAKE_CUDA_COMPILER_VERSION
+# 3. Parse and update CMAKE_CUDA_ARCHITECTURES to override `all` and `all-major` versions
+#    as well as create PTX for the last arch only
+
+message(STATUS "Configuring CUDA Architectures")
+
+# Default
+# Needed before enable_language(CUDA) or project(... LANGUAGE CUDA)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    message(STATUS "CMAKE_CUDA_ARCHITECTURES not defined, setting it to `native`")
+    set(CMAKE_CUDA_ARCHITECTURES native)
+endif()
+
+# Enable CUDA language
+# Generates CMAKE_CUDA_COMPILER_ID and CMAKE_CUDA_COMPILER_VERSION needed below
+enable_language(CUDA)
+
+# Function to filter archs and create PTX for last arch
+function(update_cmake_cuda_architectures supported_archs warn)
+    list(APPEND CMAKE_MESSAGE_CONTEXT "update_cmake_cuda_architectures")
+
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)
+            foreach(_blackwell_arch IN ITEMS "100" "120")
+                if("${_blackwell_arch}" IN_LIST supported_archs AND ${warn})
+                    message(WARNING "sm${_blackwell_arch} (Blackwell) not supported with nvcc < 12.8.0")
+                endif()
+                list(REMOVE_ITEM supported_archs "${_blackwell_arch}")
+            endforeach()
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.0.0)
+            if("90a" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm90a not supported with nvcc < 12.0.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "90a")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.8.0)
+            if("90" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm90 not supported with nvcc < 11.8.0")
+            endif()
+            if("89" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm89 not supported with nvcc < 11.8.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "90")
+            list(REMOVE_ITEM supported_archs "89")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.5.0)
+            if("87" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm87 not supported with nvcc < 11.5.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "87")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.2.0)
+            if("86" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm86 not supported with nvcc < 11.2.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "86")
+        endif()
+    endif()
+
+    # Create SASS for all architectures in the list and
+    # create PTX for the latest architecture for forward-compatibility.
+    list(POP_BACK supported_archs latest_arch)
+    list(TRANSFORM supported_archs APPEND "-real")
+    list(APPEND supported_archs ${latest_arch})
+
+    set(CMAKE_CUDA_ARCHITECTURES ${supported_archs} PARENT_SCOPE)
+endfunction()
+
+# CMake "all" and "all-major" have too many CUDA archs, all the way back to sm_20
+#   https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/CUDA/architectures.cmake
+# Rapids does not list/support embedded devices (Xavier sm_72, Orin sm_87, Thor sm_90a)
+#   https://github.com/rapidsai/rapids-cmake/blob/branch-23.09/rapids-cmake/cuda/set_architectures.cmake#L60)
+# We need to have our own logic to select our own architectures and create PTX for the latest arch
+# for forward compatibility. Only keep the default cmake behavior for native archs input.
+# Start with "70", this is the lowest architecture supported by cuFFTDx
+if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
+    set(CMAKE_CUDA_ARCHITECTURES "70;72;75;80;86;87;89;90;90a;100;120")
+    update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
+elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major")
+    set(CMAKE_CUDA_ARCHITECTURES "70;80;90;100")
+    update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
+elseif(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+    update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" TRUE)
+endif()
+
+message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")


### PR DESCRIPTION
Imports the CMake build files from \`cmake-build\` onto main (which has sm_120 in the Makefile but no CMake support yet), then extends the default CUDA arch list to include sm_100 / sm_120 with proper version gating.

## What changes

- **\`CMakeLists.txt\`** (new) — default \`CMAKE_CUDA_ARCHITECTURES\` is now \`75;80;86;87;89;90;90a;100;120\`. Adds sm_86 (Ampere desktop / RTX 3000) too, matching the Windows side.
- **\`cmake/SetupCUDA.cmake\`** (new) — version-aware arch filtering. New guard drops sm_100 / sm_120 when \`nvcc < 12.8.0\` (the first CUDA release that supports Blackwell), with a warning when the user explicitly requested them. Mirrors the existing pattern for sm_90a (< 12.0), sm_89/90 (< 11.8), etc.

## Why now

The \`kspacefirstorder-unified\` repo's CMake-based CI workflow (on the \`ci-multi-platform-experiments\` branch) calls:

\`\`\`bash
cmake -S repos/kspaceFirstOrder-cuda-linux -B build/cuda-linux ...
\`\`\`

When the unified repo's submodule SHA was bumped to current main (\`072ec8f\`, post-#4) — which only has the Makefile — the CMake configure failed with:

> CMake Error: The source directory \"...repos/kspaceFirstOrder-cuda-linux\" does not appear to contain CMakeLists.txt.

This PR closes that gap. After merge, the unified repo can bump cuda-linux to a SHA that has both sm_120 *and* CMakeLists.txt, and the unified CI's CMake build succeeds.

## Test plan

- [ ] Local \`cmake -S . -B build\` configures cleanly on a CUDA 13.0 host
- [ ] \`cmake --build build\` produces \`kspaceFirstOrder-CUDA\` with the Blackwell arches included
- [ ] On a CUDA 12.2 host, configure logs warn "sm_100/sm_120 (Blackwell) not supported with nvcc < 12.8.0" and the binary builds with sm_75..sm_90a only
- [ ] unified CI passes after submodule SHA bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `CMakeLists.txt` and `cmake/SetupCUDA.cmake` to enable CMake-based builds, mirroring the existing Makefile and extending the default CUDA architecture list to include Blackwell (sm_100/sm_120) with version-aware filtering for older nvcc toolchains.

- `CMakeLists.txt`: new build definition covering CUDA + CXX sources, dependency discovery (CUDAToolkit, HDF5, ZLIB, OpenMP), CPU-arch tuning options (`native`/`avx`/`avx2`/`avx512`), and fast-math flags matching the legacy Makefile.
- `cmake/SetupCUDA.cmake`: arch-filtering helper that drops unsupported architectures based on `nvcc` version, adds PTX for the newest arch for forward-compatibility, and handles `all`/`all-major`/`native` special values.
- `.gitignore`: adds `build/**` to exclude the CMake build tree.

<h3>Confidence Score: 3/5</h3>

The CUDA arch-filtering logic and build structure are sound, but the HDF5 HL target check will hard-fail on common system-installed HDF5 configurations before any compilation begins.

The `hdf5::hdf5_hl` target check only matches when HDF5 ships its own CMake config package. On distro-installed HDF5 (Ubuntu libhdf5-dev, RHEL hdf5-devel) where CMake's built-in FindHDF5 module runs instead, the target is named `HDF5::HDF5_HL` and the lowercase check evaluates to false, triggering an unconditional FATAL_ERROR even though the library is fully present. This would block the CI workflow this PR is specifically meant to unblock on any host relying on a system HDF5 install.

`CMakeLists.txt` lines 186-191 — the HDF5 HL target lookup needs to cover both the config-mode lowercase target and the module-mode uppercase target.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CMakeLists.txt | New CMake build file; HDF5 HL target check uses lowercase `hdf5::hdf5_hl` which fails on module-mode HDF5 installs where only `HDF5::HDF5_HL` (uppercase) exists, causing a false FATAL_ERROR. Also redundantly passes `--device-c` alongside `CUDA_SEPARABLE_COMPILATION ON`. |
| cmake/SetupCUDA.cmake | New CUDA architecture filtering helper; version-gating logic for Blackwell (12.8+), sm_90a (12.0+), sm_89/90 (11.8+), sm_87 (11.5+), sm_86 (11.2+) is correct. Minor: stale cuFFTDx comment and missing trailing newline. |
| .gitignore | Adds `build/**` to ignore the CMake build directory; straightforward and correct. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CMakeLists.txt project CXX only] --> B[Set CMAKE_CUDA_ARCHITECTURES 75;80;86;87;89;90;90a;100;120]
    B --> C[include SetupCUDA.cmake]
    C --> D{CMAKE_CUDA_ARCHITECTURES?}
    D -- all --> E[Expand to full list 70..120]
    D -- all-major --> F[Expand to 70;80;90;100]
    D -- native --> G[Skip filtering use native]
    D -- explicit list --> H[update_cmake_cuda_architectures warn=TRUE]
    E --> H2[update_cmake_cuda_architectures warn=FALSE]
    F --> H2
    H --> I{nvcc version checks}
    H2 --> I
    I -- lt 11.2 --> J[drop sm_86]
    I -- lt 11.5 --> K[drop sm_87]
    I -- lt 11.8 --> L[drop sm_89 sm_90]
    I -- lt 12.0 --> M[drop sm_90a]
    I -- lt 12.8 --> N[drop sm_100 sm_120]
    J & K & L & M & N --> O[POP_BACK latest arch append -real to rest latest gets PTX]
    O --> P[enable_language CUDA with filtered arch list]
    G --> P
    P --> Q[find_package CUDAToolkit HDF5 ZLIB OpenMP]
    Q --> R[add_executable kspaceFirstOrder-CUDA]
    R --> S[Apply CPU arch flags fast-math OpenMP CUDA separable compilation]
```

<sub>Reviews (1): Last reviewed commit: ["Add CMakeLists.txt + cmake/SetupCUDA.cma..."](https://github.com/waltsims/kspacefirstorder-cuda-linux/commit/acb53ce306660940e0329a8420998c1de4ed46ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32460172)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->