### PR TITLE
Pre-filter Blackwell archs before enable_language(CUDA)

### DIFF
--- a/cmake/SetupCUDA.cmake
+++ b/cmake/SetupCUDA.cmake
@@ -28,6 +28,44 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES native)
 endif()
 
+# Pre-enable_language pre-filter: probe nvcc version BEFORE
+# enable_language(CUDA) so we can drop architectures the installed
+# toolchain doesn't support. Otherwise the test compile done inside
+# enable_language() fails with "Unsupported gpu architecture" before
+# CMAKE_CUDA_COMPILER_VERSION is set and our post-enable filter (in
+# update_cmake_cuda_architectures below) gets a chance to run.
+#
+# Currently this only needs to handle the Blackwell archs (100, 120)
+# which require nvcc >= 12.8; older arches in our default list
+# (75..90a) work on every nvcc the project supports.
+if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+    if(NOT DEFINED CMAKE_CUDA_COMPILER)
+        find_program(_probe_nvcc nvcc
+            PATHS ENV CUDAToolkit_ROOT ENV CUDA_HOME ENV CUDA_PATH
+            PATH_SUFFIXES bin)
+    else()
+        set(_probe_nvcc "${CMAKE_CUDA_COMPILER}")
+    endif()
+    if(_probe_nvcc)
+        execute_process(
+            COMMAND "${_probe_nvcc}" --version
+            OUTPUT_VARIABLE _probe_nvcc_version_output
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+        if(_probe_nvcc_version_output MATCHES "release ([0-9]+)\\.([0-9]+)")
+            math(EXPR _probe_cuda_num "${CMAKE_MATCH_1} * 100 + ${CMAKE_MATCH_2}")
+            if(_probe_cuda_num LESS 1208)
+                foreach(_blackwell_arch IN ITEMS "100" "120")
+                    if("${_blackwell_arch}" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+                        message(STATUS "Pre-filter: dropping sm_${_blackwell_arch} (Blackwell) — nvcc ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} predates 12.8")
+                        list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES "${_blackwell_arch}")
+                    endif()
+                endforeach()
+            endif()
+        endif()
+    endif()
+endif()
+
 # Enable CUDA language
 # Generates CMAKE_CUDA_COMPILER_ID and CMAKE_CUDA_COMPILER_VERSION needed below
 enable_language(CUDA)


### PR DESCRIPTION
Fixes a CMake configure failure that hit waltsims/kspacefirstorder-unified CI on the linux-cuda 12.2.0 leg as soon as we bumped the submodule pin to the SHA that includes the default Blackwell arch list (#6 merge c6d70dc).

```
nvcc fatal: Unsupported gpu architecture 'compute_100'
CMake Error at .../CMakeTestCUDACompiler.cmake:59 (message)
```

Root cause: `enable_language(CUDA)` runs `CMakeTestCUDACompiler` which compiles a test file with the FULL `CMAKE_CUDA_ARCHITECTURES` list. The post-enable filter in `update_cmake_cuda_architectures` runs too late — the test compile happens inside `enable_language(CUDA)`, before `CMAKE_CUDA_COMPILER_VERSION` is set.

Fix: probe `nvcc --version` directly *before* `enable_language(CUDA)` and pre-drop `sm_100` / `sm_120` from `CMAKE_CUDA_ARCHITECTURES` when the detected toolchain is older than 12.8. The post-enable filter still runs afterwards for everything else.

## Test plan

- [ ] CUDA 12.2 host: configure succeeds, build produces binary with only sm_75..sm_90a
- [ ] CUDA 13.0 host: configure succeeds with full sm_75..sm_120 list
- [ ] unified CI's linux-cuda 12.2.0 leg passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CMake configure failure that occurs when `enable_language(CUDA)` tries to compile its test file using an explicit arch list that includes Blackwell SM targets (`sm_100`, `sm_120`) on a CUDA toolchain older than 12.8. The existing post-`enable_language` filter in `update_cmake_cuda_architectures` runs too late to help.

- Adds a pre-`enable_language` block that probes `nvcc --version` directly (either via `CMAKE_CUDA_COMPILER` if already set, or via `find_program` against common CUDA env-var paths and the system PATH) and strips `sm_100`/`sm_120` from the arch list whenever the detected version is below 12.8.
- The `native`, `all`, and `all-major` keywords are all correctly excluded from the early filter — CMake handles these as opaque keywords during the test compile so they do not trigger the unsupported-arch error.
- The post-`enable_language` filter is left intact to remain the authoritative runtime authority once `CMAKE_CUDA_COMPILER_VERSION` is available.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly intercepts the Blackwell arch problem before enable_language(CUDA) runs, and all edge cases (native, all, all-major, non-nvcc compilers) are handled without regression.

The core logic is sound and the two-phase filter is internally consistent. Three minor observations: find_program writes _probe_nvcc to the CMake cache as a side effect; no diagnostic is emitted when the probe skips due to a missing nvcc binary; and the major*100+minor arithmetic works today but is an implicit assumption about CUDA minor-version width. None of these affect correctness in the target CI scenario.

cmake/SetupCUDA.cmake — the only changed file; the pre-filter block at lines 41-67 is the area to focus on.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cmake/SetupCUDA.cmake | Adds a pre-`enable_language(CUDA)` nvcc probe that strips sm_100/sm_120 from an explicit arch list when the detected toolchain is older than 12.8, fixing a configure-time crash; minor style concerns around cache pollution and version arithmetic robustness. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([SetupCUDA.cmake starts]) --> B{CMAKE_CUDA_ARCHITECTURES\ndefined?}
    B -- No --> C[Set to 'native']
    B -- Yes --> D{Equals 'native'?}
    C --> D
    D -- Yes --> G
    D -- No --> E{CMAKE_CUDA_COMPILER\ndefined?}
    E -- No --> F[find_program nvcc\nvia env vars + PATH]
    E -- Yes --> F2[use CMAKE_CUDA_COMPILER]
    F --> H{nvcc found?}
    F2 --> H
    H -- No --> G
    H -- Yes --> I[execute_process\nnvcc --version]
    I --> J{matches 'release X.Y'?}
    J -- No --> G
    J -- Yes --> K{X*100+Y < 1208?}
    K -- No --> G
    K -- Yes --> L[Remove '100' and '120'\nfrom CMAKE_CUDA_ARCHITECTURES]
    L --> G[enable_language CUDA]
    G --> M{arch value?}
    M -- all --> N[Set 70..120 list\nupdate_cmake_cuda_architectures]
    M -- all-major --> O[Set 70 80 90 100\nupdate_cmake_cuda_architectures]
    M -- explicit list --> P[update_cmake_cuda_architectures]
    M -- native --> Q[No post-processing]
    N --> R([Done])
    O --> R
    P --> R
    Q --> R
```

<sub>Reviews (1): Last reviewed commit: ["Pre-filter Blackwell archs before enable..."](https://github.com/waltsims/kspacefirstorder-cuda-linux/commit/e65c5cf9b2ff49dcecaf5b57b5d9ea0608067c71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32460645)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->